### PR TITLE
BUG FIX: Word of mouth controller depends on UIKit not Foundation

### DIFF
--- a/objc/WordOfMouth/TSWordOfMouthController.h
+++ b/objc/WordOfMouth/TSWordOfMouthController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Tapstream. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "TSHelpers.h"
 #import "TSOffer.h"
 #import "TSReward.h"


### PR DESCRIPTION
Small change to CocoaTouch framework is `#import`ed for the `TSWordOfMouthController` class. In a project without a precompiled header, this throws a compile error because `UIViewController` is undefined.