### PR TITLE
BUG FIX: Fixing up compiler warnings when building SDK for iOS 8-only projects

### DIFF
--- a/objc/Tapstream/TSAppEventSourceImpl.m
+++ b/objc/Tapstream/TSAppEventSourceImpl.m
@@ -117,6 +117,9 @@ static void TSLoadStoreKitClasses()
 
 - (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray *)transactions
 {
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+    
 	for(SKPaymentTransaction *transaction in transactions)
 	{
 		switch(transaction.transactionState)
@@ -132,11 +135,14 @@ static void TSLoadStoreKitClasses()
 				
 #if TEST_IOS || TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 				// For ios 7 and up, try to get the Grand Unified Receipt.
-				if(floor(NSFoundationVersionNumber) >= NSFoundationVersionNumber_iOS_7_0)
-				{
-					receipt = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] appStoreReceiptURL]];
+                NSBundle *mainBundle = [NSBundle mainBundle];
+                if ([mainBundle respondsToSelector:@selector(appStoreReceiptURL)])
+                {
+                    receipt = [NSData dataWithContentsOfURL:[mainBundle appStoreReceiptURL]];
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 70000
 				}else{ // For (real) old ios versions, use transactionReceipt.
 					receipt = transaction.transactionReceipt;
+#endif
 				}
 #else
 				// For mac, try to load the receipt out of the bundle.  If appStoreReceiptURL method is
@@ -153,7 +159,7 @@ static void TSLoadStoreKitClasses()
 				receipt = [NSData dataWithContentsOfURL:receiptUrl];
 #endif
 				
-				if(receipt && transaction.transactionIdentifier != nil)
+				if(receipt && transaction.transactionIdentifier)
 				{
 					@synchronized(self)
 					{
@@ -165,10 +171,18 @@ static void TSLoadStoreKitClasses()
             case SKPaymentTransactionStateFailed:
             case SKPaymentTransactionStatePurchasing:
             case SKPaymentTransactionStateRestored:
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+            case SKPaymentTransactionStateDeferred:
+            {
+                
+            }
+#endif
             break;
             
 		}
 	}
+#endif
+#endif
 }
 
 - (void)paymentQueue:(SKPaymentQueue *)queue removedTransactions:(NSArray *)transactions


### PR DESCRIPTION
I'm suggesting the following changes:
- Conditionally compile deprecated StoreKit API
- Conditionally compile new StoreKit enum value
- Check `respondsToSelector` instead of `NSFoundationVersionNumber`

**Background:**
We've added the Tapstream SDK to our project as a git submodule. Our project's base SDK is iOS 8.3 (Xcode 6.3) and the deployment target is iOS 8.0. When compiling the tip of `tapstream-sdk` master, the following two compiler warnings are generated in `TSAppEventSourceImpl.m`  when building for iOS device:
```
TSAppEventSourceImpl.m:139:28: warning: 'transactionReceipt' is deprecated: first deprecated in iOS 7.0 - Use -[NSBundle appStoreReceiptURL] [-Wdeprecated-declarations]
                                        receipt = transaction.transactionReceipt;
                                                              ^
```
```
TSAppEventSourceImpl.m:122:10: warning: enumeration value 'SKPaymentTransactionStateDeferred' not handled in switch [-Wswitch]
                switch(transaction.transactionState)
                       ^
```

**Pull Request:**
In this pull request, I am attempting to conditionally compile-out the deprecated method and compile-in the unhandled enum value.

Following the guidance in [Apple's SDK Compatibility Guide](https://developer.apple.com/library/ios/documentation/DeveloperTools/Conceptual/cross_development/Introduction/Introduction.html#//apple_ref/doc/uid/10000163-BCICHGIE) (specifically the section on [Conditionally Compiling for Different SDKs](https://developer.apple.com/library/ios/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html#//apple_ref/doc/uid/20002000-1114741-CJADDEIB)) I am using two macros to set up preprocessor checks to determine the Base SDK (`__IPHONE_OS_VERSION_MAX_ALLOWED`) and Deployment Target (`__IPHONE_OS_VERSION_MIN_REQUIRED`).

On line 140, I check if the deployment target is less than iOS 7.0. If it is, then opt-in to compiling the deprecated method: `-[SKPaymentTransaction transactionReceipt]`.

On line 172, I check if the the Base SDK is greater than or equal to iOS 8.0. If it is, then opt-in to compiling the new case: `SKPaymentTransactionStateDeferred`. I don't know if there is anything for the Tapstream SDK to do with this case, but I've gone ahead and set up curly braces just incase.

**Discussion:**
These changes clear both of the aforementioned compiler warnings, and (watching the preprocessor output in the assistant editor) give the correct behavior for projects built with earlier versions of Xcode or that target much earlier versions of iOS. However, I understand this PR may not land because it has the potential to increase code complexity and maintenance. The version-max-allowed code changes should be temporary complexity since [Apple is requiring a Base SDK of 8.0 after June 1st](https://developer.apple.com/news/?id=04082015a), which means the enum value should be available for all users.

I hope, of course, that the code changes are considered because currently we're treating warnings as errors in our project, but have to turn that off for the Tapstream SDK. Thank you.