### PR TITLE
BUG FIX: Activity view controller's completion handler should be explicitly set to nil

### DIFF
--- a/objc/WordOfMouth/TSWordOfMouthController.m
+++ b/objc/WordOfMouth/TSWordOfMouthController.m
@@ -291,33 +291,69 @@
     if(accepted) {
         TSOffer *offer = self.offerViewController.offer;
         UIViewController *parent = self.offerViewController.parentViewController;
-
-
-		UIActivityViewController* c = [[UIActivityViewController alloc]
-									   initWithActivityItems:@[offer.message] applicationActivities:nil];
-
-		[c setCompletionHandler:^(NSString* type, BOOL completed){
-			if(completed){
-				NSString* cleanedType = type;
-
-				if([type isEqualToString:UIActivityTypeMail]){
-					cleanedType = @"email";
-				}else if([type isEqualToString:UIActivityTypeMessage]){
-					cleanedType = @"messaging";
-				}else if([type isEqualToString:UIActivityTypePostToFacebook]){
-					cleanedType = @"facebook";
-				}else if([type isEqualToString:UIActivityTypePostToTwitter]){
-					cleanedType = @"twitter";
-				}
-
-				[self completedShare:offer.ident socialMedium:cleanedType];
-			}
-		}];
-
-		[parent presentViewController:c animated:YES completion:nil];
-	}
-
-	// Clean up offer view
+        
+        
+        UIActivityViewController* c = [[UIActivityViewController alloc]
+                                       initWithActivityItems:@[offer.message] applicationActivities:nil];
+        
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
+        
+        __weak typeof(c) weakC = c;
+        
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+        [c setCompletionWithItemsHandler:^(NSString *activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
+            
+            __strong typeof(weakC) strongC = weakC;
+            
+            if (completed) {
+                NSString* cleanedType = activityType;
+                
+                if([activityType isEqualToString:UIActivityTypeMail]){
+                    cleanedType = @"email";
+                }else if([activityType isEqualToString:UIActivityTypeMessage]){
+                    cleanedType = @"messaging";
+                }else if([activityType isEqualToString:UIActivityTypePostToFacebook]){
+                    cleanedType = @"facebook";
+                }else if([activityType isEqualToString:UIActivityTypePostToTwitter]){
+                    cleanedType = @"twitter";
+                }
+                
+                [self completedShare:offer.ident socialMedium:cleanedType];
+                
+                strongC.completionWithItemsHandler = nil;
+            }
+        }];
+#else
+        [c setCompletionHandler:^(NSString* type, BOOL completed){
+            
+            __strong typeof(weakC) strongC = weakC;
+            
+            if(completed){
+                NSString* cleanedType = type;
+                
+                if([type isEqualToString:UIActivityTypeMail]){
+                    cleanedType = @"email";
+                }else if([type isEqualToString:UIActivityTypeMessage]){
+                    cleanedType = @"messaging";
+                }else if([type isEqualToString:UIActivityTypePostToFacebook]){
+                    cleanedType = @"facebook";
+                }else if([type isEqualToString:UIActivityTypePostToTwitter]){
+                    cleanedType = @"twitter";
+                }
+                
+                [self completedShare:offer.ident socialMedium:cleanedType];
+                
+                strongC.completionHandler = nil;
+            }
+        }];
+        
+#endif
+#endif
+        
+        [parent presentViewController:c animated:YES completion:nil];
+    }
+    
+    // Clean up offer view
     [self.offerViewController willMoveToParentViewController:nil];
     [self.offerViewController.view removeFromSuperview];
     [self.offerViewController removeFromParentViewController];


### PR DESCRIPTION
Some of the changes in this pull request are similar to #50.

I find it odd that `UIActivityViewController.h` makes the following code comment for the completion handlers:
```
@property(nonatomic,copy) UIActivityViewControllerCompletionHandler completionHandler NS_DEPRECATED_IOS(6_0, 8_0, "Use completionWithItemsHandler instead.");  // set to nil after call
@property(nonatomic,copy) UIActivityViewControllerCompletionWithItemsHandler completionWithItemsHandler NS_AVAILABLE_IOS(8_0); // set to nil after call
```

This kind of requirement for a completion handler is pretty unusual (as far as I've seen from CocoaTouch). Leaky abstraction, Apple? I haven't run the allocations instrument to confirm a retain cycle exists since early iOS 7; maybe these code comments aren't accurate.

The included code does the strong-weak dance to make sure the activity view controller's completion handler is set to `nil`.